### PR TITLE
fixed indentation and file reference

### DIFF
--- a/jazzhr/__init__.py
+++ b/jazzhr/__init__.py
@@ -1,1 +1,1 @@
-from jazzhr import *
+from jazzhr.jazzhr import *

--- a/jazzhr/jazzhr.py
+++ b/jazzhr/jazzhr.py
@@ -33,7 +33,7 @@ class JazzhrPreprocessor(grow.Preprocessor):
     def bind_jobs(self, api_key, collection_path):
         url = JazzhrPreprocessor.JOBS_URL.format(api_key=api_key)
         resp = requests.get(url)
-	if resp.status_code != 200:
+        if resp.status_code != 200:
             raise Error('Error requesting -> {}'.format(url))
         content = resp.json()
         self._bind(collection_path, content)
@@ -73,7 +73,7 @@ class JazzhrPreprocessor(grow.Preprocessor):
         url = JazzhrPreprocessor.JOB_URL.format(
                 api_key=api_key, job_id=item['id'])
         resp = requests.get(url)
-	if resp.status_code != 200:
+        if resp.status_code != 200:
             raise Error('Error requesting -> {}'.format(url))
         content = resp.json()
         return content


### PR DESCRIPTION
The indentation in the 2 lines modified was using tabs instead of spaces and was badly indented causing build to crash, the import statement was referencing only the folder instead of the file.